### PR TITLE
chore: golang-cjxd8-test2 to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.118
 - name: golang-cjxd8-test2
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
chore: Promote golang-cjxd8-test2 to version 0.0.2